### PR TITLE
Find proc address for glEGLImageTargetTexture2DOES during runtime

### DIFF
--- a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmscreen.cpp
+++ b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms/qeglfskmsgbmscreen.cpp
@@ -363,7 +363,12 @@ void QEglFSKmsGbmScreen::recordFrame(EGLClientBuffer bo, int width, int height)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glBindTexture(GL_TEXTURE_2D, texture);
-    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    PFNGLEGLIMAGETARGETTEXTURE2DOESPROC imageTexture2D =
+        reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(eglGetProcAddress("glEGLImageTargetTexture2DOES"));
+    if (imageTexture2D)
+        imageTexture2D(GL_TEXTURE_2D, image);
+    else
+        qCritical("No glEGLImageTargetTexture2DOES function available");
 
     // OpenGL 3.0 functions
     auto glContext = QOpenGLContext::currentContext();


### PR DESCRIPTION
glEGLImageTargetTexture2DOES is not defined in the symbol table in newer
versions of mesa.

fixes:
| liri-shell: symbol lookup error: /usr/lib/plugins/liri/egldeviceintegrations/libeglfs-kms-integration.so: undefined symbol: glEGLImageTargetTexture2DOES

Inspired by [1] / addresses [2]

[1] https://github.com/intel/libyami/commit/394dd742c40333336b3eb197c627db4239b93e84
[2] https://github.com/lirios/eglfs/issues/8

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>